### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,13 +31,12 @@ class ItemsController < ApplicationController
 
   def update
     @item = Item.find(params[:id])
-
-    @item.image.attach(params[:item][:image]) if params[:item][:image].present? && @item.image != params[:item][:image]
-
     if @item.update(item_params)
       redirect_to item_path(@item)
     else
-      render :edit
+      puts 'Form Data:'
+      puts item_params.inspect
+      render 'new', status: :unprocessable_entity
     end
   end
 
@@ -57,11 +56,19 @@ class ItemsController < ApplicationController
   end
 
   def check_user
-    #   ログインユーザーと編集対象のプロトタイプのユーザーが一致しない場合、トップページにリダイレクト
-    return if current_user == @item.user
-
-    redirect_to root_path
+    @item = Item.find(params[:id])
+  
+    if user_signed_in?
+      if current_user == @item.user
+        return
+      else
+        redirect_to root_path
+      end
+    else
+        redirect_to root_path
+    end
   end
+  
 
   def set_item
     @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,7 +22,6 @@ class ItemsController < ApplicationController
       render 'new', status: :unprocessable_entity
     end
   end
-  
 
   #  def destroy
   #    item = Item.find(params[:id])
@@ -30,23 +29,21 @@ class ItemsController < ApplicationController
   #    redirect_to root_path
   #  end
 
-    def update
-      @item = Item.find(params[:id])
-    
-      if params[:item][:image].present? && @item.image != params[:item][:image]
-        @item.image.attach(params[:item][:image])
-      end
-    
-      if @item.update(item_params)
-        redirect_to item_path(@item)
-      else
-        render :edit
-      end
+  def update
+    @item = Item.find(params[:id])
+
+    @item.image.attach(params[:item][:image]) if params[:item][:image].present? && @item.image != params[:item][:image]
+
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit
     end
-    
-    def edit
-      @item = Item.find(params[:id])
-    end
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
 
   def show
     @item = Item.find(params[:id])
@@ -59,12 +56,12 @@ class ItemsController < ApplicationController
                                  :prefecture_id, :shipping_day_id, :sales_price)
   end
 
-    def check_user
-#   ログインユーザーと編集対象のプロトタイプのユーザーが一致しない場合、トップページにリダイレクト
-      unless current_user == @item.user
-        redirect_to root_path
-      end
-    end
+  def check_user
+    #   ログインユーザーと編集対象のプロトタイプのユーザーが一致しない場合、トップページにリダイレクト
+    return if current_user == @item.user
+
+    redirect_to root_path
+  end
 
   def set_item
     @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,7 +30,7 @@ class ItemsController < ApplicationController
   #  end
 
   def edit
-    @item
+  end
 
   def update
     if @item.update(item_params)
@@ -43,7 +43,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item
   end
 
   private
@@ -71,4 +70,5 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  #  before_action :set_item, only: [:show, :edit, :update, :destroy]
-  #  before_action :check_user, only: [:edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :check_user, only: [:edit, :update]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -22,6 +22,7 @@ class ItemsController < ApplicationController
       render 'new', status: :unprocessable_entity
     end
   end
+  
 
   #  def destroy
   #    item = Item.find(params[:id])
@@ -29,18 +30,18 @@ class ItemsController < ApplicationController
   #    redirect_to root_path
   #  end
 
-  #  def update
-  #    @item = Item.find(params[:id])
-  #    if @item.update(item_params)
-  #      redirect_to item_path(@item)
-  #    else
-  #      render 'edit'
-  #    end
-  #  end
+    def update
+      @item = Item.find(params[:id])
+      if @item.update(item_params)
+        redirect_to item_path(@item)
+      else
+        render 'edit'
+      end
+    end
 
-  #  def edit
-  #    @item = Item.find(params[:id])
-  #  end
+    def edit
+      @item = Item.find(params[:id])
+    end
 
   def show
     @item = Item.find(params[:id])
@@ -53,12 +54,12 @@ class ItemsController < ApplicationController
                                  :prefecture_id, :shipping_day_id, :sales_price)
   end
 
-  #  def check_user
-  # ログインユーザーと編集対象のプロトタイプのユーザーが一致しない場合、トップページにリダイレクト
-  #    unless current_user == @item.user
-  #      redirect_to root_path
-  #    end
-  #  end
+    def check_user
+   ログインユーザーと編集対象のプロトタイプのユーザーが一致しない場合、トップページにリダイレクト
+      unless current_user == @item.user
+        redirect_to root_path
+      end
+    end
 
   def set_item
     @item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -55,7 +55,7 @@ class ItemsController < ApplicationController
   end
 
     def check_user
-   ログインユーザーと編集対象のプロトタイプのユーザーが一致しない場合、トップページにリダイレクト
+#   ログインユーザーと編集対象のプロトタイプのユーザーが一致しない場合、トップページにリダイレクト
       unless current_user == @item.user
         redirect_to root_path
       end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,23 +29,21 @@ class ItemsController < ApplicationController
   #    redirect_to root_path
   #  end
 
+  def edit
+    @item
+
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item)
     else
       puts 'Form Data:'
       puts item_params.inspect
-      render 'new', status: :unprocessable_entity
+      render 'edit', status: :unprocessable_entity
     end
   end
 
-  def edit
-    @item = Item.find(params[:id])
-  end
-
   def show
-    @item = Item.find(params[:id])
+    @item
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -53,8 +53,6 @@ class ItemsController < ApplicationController
   end
 
   def check_user
-    @item = Item.find(params[:id])
-  
     if user_signed_in?
       if current_user == @item.user
         return

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -32,13 +32,18 @@ class ItemsController < ApplicationController
 
     def update
       @item = Item.find(params[:id])
+    
+      if params[:item][:image].present? && @item.image != params[:item][:image]
+        @item.image.attach(params[:item][:image])
+      end
+    
       if @item.update(item_params)
         redirect_to item_path(@item)
       else
-        render 'edit'
+        render :edit
       end
     end
-
+    
     def edit
       @item = Item.find(params[:id])
     end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,10 +9,7 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
-
-    <% if f.object && f.object.errors.any? %>
     <%= render 'shared/error_messages', model: f.object %>
-    <% end %>
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -4,11 +4,11 @@ app/assets/stylesheets/items/new.css %>
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-    <script src="/app/javascript/item_price.js"></script>
+
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <% if f.object && f.object.errors.any? %>
     <%= render 'shared/error_messages', model: f.object %>
@@ -144,7 +144,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,7 +133,7 @@
       <%= link_to item_path(item) do %>
       <div class='item-img-content'>
         <%= image_tag item.image, class: "item-img" %>
-        <%# 商品が売れていればsold outを表示しましょう %>
+        <% if @user_item %>
         <div class='sold-out'>
           <span>Sold Out!!</span>
         </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -6,7 +6,7 @@
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
-    <%= render 'shared/error_messages', model: @item %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,7 +8,7 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class: "item-box-img" %>
-       <%# 商品が売れていればsold outを表示しましょう %>
+       <% if @user_item %>
         <div class="sold-out">
           <span>Sold Out!!</span>
         </div>
@@ -26,7 +26,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to "#", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "#", item_path(@item), class: "item-destroy", data: { turbo_method: :delete } %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "#", item_path(@item), class: "item-destroy", data: { turbo_method: :delete } %>
+        <%= link_to "削除", "#", class: "item-destroy", data: { turbo_method: :delete } %>
 
 
      <% else %>


### PR DESCRIPTION
#What
商品情報編集機能
#Why
商品情報編集機能を実装しました

- [ ] ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/309ffa63684b180bfcf70174fc08ca1d
- [ ] 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/4c825709deabe695ce28560535106e80
- [ ] 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
![image](https://github.com/miniity/furima-39581/assets/142400121/52466d92-049d-4659-92a0-6774cc89fff6)

- [ ] 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/d8ac6250639c55db62b3897c47b33cf0
- [ ] ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/2da33fee209b24d5973e3636735e72de
- [ ] ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/089a4269b479c99e8010f2d091d87553
- [ ] 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/9e000cd6f912cd79f4ea66650ea08979

